### PR TITLE
Allow passing custom launch options to Puppeteer

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ const captureWebsite = async (url, options) => {
 		screenshotOptions.omitBackground = !options.defaultBackground;
 	}
 
-	const {launchOptions} = options;
+	const launchOptions = {...options.launchOptions};
 
 	if (options.debug) {
 		launchOptions.headless = false;

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ const captureWebsite = async (url, options) => {
 		screenshotOptions.omitBackground = !options.defaultBackground;
 	}
 
-	const launchOptions = options.launchOptions;
+	const {launchOptions} = options;
 
 	if (options.debug) {
 		launchOptions.headless = false;

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ const captureWebsite = async (url, options) => {
 		timeout: 60, // The Puppeteer default of 30 is too short
 		delay: 0,
 		debug: false,
+		launchOptions: {},
 		_keepAlive: false,
 		...options
 	};
@@ -88,10 +89,10 @@ const captureWebsite = async (url, options) => {
 		screenshotOptions.omitBackground = !options.defaultBackground;
 	}
 
-	const launchOptions = {};
+	const launchOptions = options.launchOptions;
 
 	if (options.debug) {
-		launchOptions.headless = !options.debug;
+		launchOptions.headless = false;
 	}
 
 	const browser = options._browser || await puppeteer.launch(launchOptions);

--- a/readme.md
+++ b/readme.md
@@ -351,6 +351,19 @@ Default: `false`
 
 Show the browser window so you can see what it's doing.
 
+Note: This overrides `launchOptions.headless = false`.
+
+##### launchOptions
+
+Type: `Object`<br>
+Default: `{}`
+
+Options passed to `puppeteer.launch([options])`.
+See [puppeteer docs](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
+
+Note: Some launch options will be overridden by other options. For example,
+`debug: true` sets `launchOptions.headless = false`.
+
 ### captureWebsite.devices
 
 Type: `string[]`

--- a/readme.md
+++ b/readme.md
@@ -358,11 +358,9 @@ Note: This overrides `launchOptions.headless = false`.
 Type: `Object`<br>
 Default: `{}`
 
-Options passed to `puppeteer.launch([options])`.
-See [puppeteer docs](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
+Options passed to [`puppeteer.launch()`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
 
-Note: Some launch options will be overridden by other options. For example,
-`debug: true` sets `launchOptions.headless = false`.
+Note: Some of the launch options are overridden by the `debug` option.
 
 ### captureWebsite.devices
 


### PR DESCRIPTION
I have a case where I need to set the `executablePath` option when launching puppeteer inside a Docker container.

This PR introduces a new option `launchOptions`, which will be the object passed down to `puppeteer.launch(options)`.

I also removed the debug option since it now is equivalent to
```javascript
{
	launchOptions: {
		headless: false
	}
}
```