### PR TITLE
Add the ability to specify the executablePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,10 @@ const captureWebsite = async (url, options) => {
 		launchOptions.headless = false;
 		launchOptions.slowMo = 100;
 	}
+	
+	if (options.executablePath) {
+		launchOptions.executablePath = options.executablePath;
+	}	
 
 	const browser = options._browser || await puppeteer.launch(launchOptions);
 	const page = await browser.newPage();


### PR DESCRIPTION
Some Linux distro (like alpine) won't work with Chrome and they need to use chromium.

This is mentioned in the puppeteer troubleshooting section https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine