### PR TITLE
Add `clip` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,242 @@
+/// <reference types="puppeteer"/>
+import {SetCookie, LaunchOptions, Page, Browser} from 'puppeteer';
+
+export interface Authentication {
+	username: string;
+	password?: string;
+}
+
+export interface BeforeScreenshot {
+	(page: Page, browser: Browser): void;
+}
+
+export interface Options {
+	/**
+	Page width.
+
+	@default 1280
+	*/
+	width?: number;
+
+	/**
+	Page height.
+
+	@default 800
+	*/
+	height?: number;
+
+	/**
+	Image type.
+
+	@default png
+	*/
+	type?: 'png' | 'jpeg';
+
+	/**
+	Image quality. Only for {type: 'jpeg'}.
+
+	@default 1
+	*/
+	quality?: number;
+
+	/**
+	Scale the webpage `n` times.
+
+	The default is what you would get if you captured a normal screenshot on a computer with a retina (High DPI) screen.
+
+	@default 2
+	*/
+	scaleFactor?: number;
+
+	/**
+	Make it look like the screenshot was taken on the specified device.
+
+	This overrides the `width`, `height`, `scaleFactor`, and `userAgent` options.
+	*/
+	emulateDevice?: string;
+
+	/**
+	Capture the full scrollable page, not just the viewport.
+
+	@default false
+	*/
+	fullPage?: boolean;
+
+	/**
+	Include the default white background.
+
+	Disabling this lets you capture screenshots with transparency.
+
+	@default true
+	*/
+	defaultBackground?: boolean;
+
+	/**
+	The number of seconds before giving up trying to load the page.
+
+	Specify `0` to disable the timeout.
+
+	@default 60
+	*/
+	timeout?: number;
+
+	/**
+	The number of seconds to wait after the page finished loading before capturing the screenshot.
+
+	This can be useful if you know the page has animations that you like it to finish before capturing the screenshot.
+
+	@default 0
+	*/
+	delay?: number;
+
+	/**
+	Wait for a DOM element matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) to appear in the page and to be visible before capturing the screenshot. It times out after `options.timeout` seconds.
+	*/
+	waitForElement?: string;
+
+	/**
+	Capture the DOM element matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). It will wait for the element to appear in the page and to be visible. It times out after `options.timeout` seconds
+	*/
+	element?: string;
+
+	/**
+	Hide DOM elements matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
+
+	Can be useful for cleaning up the page.
+
+	This sets [`visibility: hidden`](https://stackoverflow.com/a/133064/64949) on the matched elements.
+	*/
+	hideElements?: string[];
+
+	/**
+	Remove DOM elements matching the given [CSS selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
+
+	This sets [`display: none`](https://stackoverflow.com/a/133064/64949) on the matched elements, so it could potentially break the website layout.
+	*/
+	removeElements?: string[];
+
+	/**
+	Click the DOM element matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
+	*/
+	clickElement?: string;
+
+	/**
+	Inject [JavaScript modules](https://developers.google.com/web/fundamentals/primers/modules) into the page.
+
+	Accepts an array of inline code, absolute URLs, and local file paths (must have a .js extension).
+	*/
+	modules?: string[];
+
+	/**
+	Same as the `modules` option, but instead injects the code as [`<script>` instead of `<script type="module">`](https://developers.google.com/web/fundamentals/primers/modules). Prefer the `modules` option whenever possible.
+	*/
+	scripts?: string[];
+
+	/**
+	Inject CSS styles into the page.
+
+	Accepts an array of inline code, absolute URLs, and local file paths (must have a `.css` extension).
+	*/
+	styles?: string[];
+
+	/**
+	Set custom [HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers).
+
+	@default {}
+	*/
+	headers?: Headers;
+
+	/**
+	Set a custom [user agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent).
+	*/
+	userAgent?: string;
+
+	/**
+	Set cookies in [browser string format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) or [object format](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetcookiecookies).
+
+	Tip: Go to the website you want a cookie for and [copy-paste it from DevTools](https://stackoverflow.com/a/24961735/64949).
+	*/
+	cookies?: (string | SetCookie)[];
+
+	/**
+	Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
+	*/
+	authentication?: Authentication;
+
+	/**
+	The specified function is called right before the screenshot is captured. It gives you a lot of power to do custom stuff. The function can be async.
+
+	Note: Make sure to not call `page.close()` or `browser.close()`.
+	*/
+	beforeScreenshot?: BeforeScreenshot;
+
+	/**
+	Show the browser window so you can see what it's doing, redirect page console output to the terminal, and slow down each Puppeteer operation.
+
+	Note: This overrides `launchOptions` with `{headless: false, slowMo: 100}`.
+
+	@default false
+	*/
+	debug?: boolean;
+
+	/**
+	Options passed to [`puppeteer.launch()`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
+
+	Note: Some of the launch options are overridden by the `debug` option.
+
+	@default {}
+	*/
+	launchOptions?: LaunchOptions;
+}
+
+export interface FileOptions extends Options {
+	/**
+	Overwrite the destination file if it exists instead of throwing an error.
+
+	@default false
+	*/
+	overwrite?: boolean;
+}
+
+declare const captureWebsite: {
+	/**
+	Devices supported by the `emulateDevice` option.
+	*/
+	devices: string[];
+
+	/**
+	Capture a screnshot of the given `url` and save it to the given `outputFilePath`.
+
+	@param url - The URL, file URL, data URL, or local file path to the website.
+	@param outputFilePath - The path to write the screenshot.
+	@returns A promise that resolves when the screenshot is written to the given file path.
+
+	@example
+	```
+	import captureWebsite from 'capture-website';
+
+	(async () => {
+		await captureWebsite.file('https://sindresorhus.com', 'screenshot.png');
+	})();
+	```
+	*/
+	file(url: string, outputFilePath: string, options?: FileOptions): Promise<void>;
+
+	/**
+	Capture a screnshot of the given `url`.
+
+	@param url - The URL, file URL, data URL, or local file path to the website.
+	@returns The screenshot as binary.
+	*/
+	buffer(url: string, options?: Options): Promise<Buffer>;
+
+	/**
+	Capture a screnshot of the given `url`.
+
+	@param url - The URL, file URL, data URL, or local file path to the website.
+	@returns The screenshot as [Base64](https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding).
+	*/
+	base64(url: string, options?: Options): Promise<string>;
+};
+
+export default captureWebsite;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,24 @@
+import {expectType} from 'tsd';
+import captureWebsite from '.';
+
+expectType<Promise<void>>(
+	captureWebsite.file('https://github.com/sindresorhus/capture-website#readme', './page.png', {
+		cookies: [
+			{
+				name: 'id',
+				value: 'unicorn',
+				expires: Math.round(new Date('2018-10-21').getTime() / 1000)
+			}
+		]
+	})
+);
+
+expectType<Promise<string>>(
+	captureWebsite.base64('https://github.com/sindresorhus/capture-website#readme')
+);
+
+expectType<Promise<Buffer>>(
+	captureWebsite.buffer('https://github.com/sindresorhus/capture-website#readme')
+);
+
+expectType<string[]>(captureWebsite.devices);

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"capture",
@@ -39,6 +40,7 @@
 		"tough-cookie": "^3.0.1"
 	},
 	"devDependencies": {
+		"@types/puppeteer": "^1.12.3",
 		"ava": "^1.2.0",
 		"create-test-server": "^2.1.1",
 		"delay": "^4.1.0",
@@ -48,6 +50,7 @@
 		"pify": "^4.0.1",
 		"png-js": "^0.1.1",
 		"tempy": "^0.2.1",
+		"tsd": "^0.7.0",
 		"xo": "^0.24.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	],
 	"dependencies": {
 		"file-url": "^2.0.2",
-		"puppeteer": "^1.12.2",
+		"puppeteer": "^1.13.0",
 		"tough-cookie": "^3.0.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "capture-website",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"description": "Capture screenshots of websites",
 	"license": "MIT",
 	"repository": "sindresorhus/capture-website",

--- a/readme.md
+++ b/readme.md
@@ -33,15 +33,21 @@ const captureWebsite = require('capture-website');
 
 ## API
 
-### captureWebsite.file(url, filePath, [options])
+### captureWebsite.file(url, outputFilePath, [options])
 
-Returns a `Promise<void>` that resolves when the screenshot is written to the given file path.
+Capture a screnshot of the given `url` and save it to the given `outputFilePath`.
+
+Returns a `Promise<void>` that resolves when the screenshot is written.
 
 ### captureWebsite.buffer(url, [options])
+
+Capture a screnshot of the given `url`.
 
 Returns a `Promise<Buffer>` with the screenshot as binary.
 
 ### captureWebsite.base64(url, [options])
+
+Capture a screnshot of the given `url`.
 
 Returns a `Promise<string>` with the screenshot as [Base64](https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding).
 


### PR DESCRIPTION
- added `clip` option, which is core puppeteer [feature ](https://github.com/GoogleChrome/puppeteer/blob/v1.13.0/docs/api.md#pagescreenshotoptions);  
- added validation to exclude using `clip` and `element` options together;   
- added description in readme.md for new option;
- added typings;  
- added test;

Fixes #20