### PR TITLE
Add `isJavaScriptEnabled` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -150,7 +150,9 @@ declare namespace captureWebsite {
 		readonly disableAnimations?: boolean;
 
 		/**
-		Set JavaScript execution of a website.
+		Whether JavaScript on the website should be executed.
+
+		This does not affect the `scripts` and `modules` options.
 
 		@default true
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -150,6 +150,13 @@ declare namespace captureWebsite {
 		readonly disableAnimations?: boolean;
 
 		/**
+		Options to enable javascript execution on the page. If disabled, it also disable modules and scripts
+
+		@default true
+		*/
+		readonly javascriptEnabled?: boolean;
+
+		/**
 		Inject [JavaScript modules](https://developers.google.com/web/fundamentals/primers/modules) into the page.
 
 		Accepts an array of inline code, absolute URLs, and local file paths (must have a .js extension).

--- a/index.d.ts
+++ b/index.d.ts
@@ -150,11 +150,11 @@ declare namespace captureWebsite {
 		readonly disableAnimations?: boolean;
 
 		/**
-		Options to enable javascript execution on the page. If disabled, it also disable modules and scripts
+		Set JavaScript execution of a website.
 
 		@default true
 		*/
-		readonly javascriptEnabled?: boolean;
+		readonly isJavaScriptEnabled?: boolean;
 
 		/**
 		Inject [JavaScript modules](https://developers.google.com/web/fundamentals/primers/modules) into the page.

--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ const captureWebsite = async (url, options) => {
 	const browser = options._browser || await puppeteer.launch(launchOptions);
 	const page = await browser.newPage();
 
-	page.setJavaScriptEnabled(options.isJavaScriptEnabled);
+	await page.setJavaScriptEnabled(options.isJavaScriptEnabled);
 
 	if (options.debug) {
 		page.on('console', message => {
@@ -249,6 +249,9 @@ const captureWebsite = async (url, options) => {
 	}
 
 	const getInjectKey = (ext, value) => isUrl(value) ? 'url' : value.endsWith(`.${ext}`) ? 'path' : 'content';
+
+	// Reset javascript execution to true for modules
+	await page.setJavaScriptEnabled(true);
 
 	if (options.modules) {
 		await Promise.all(options.modules.map(module_ => {

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ const captureWebsite = async (url, options) => {
 		debug: false,
 		launchOptions: {},
 		_keepAlive: false,
-		javascriptEnabled: true,
+		isJavaScriptEnabled: true,
 		...options
 	};
 
@@ -181,6 +181,8 @@ const captureWebsite = async (url, options) => {
 
 	const browser = options._browser || await puppeteer.launch(launchOptions);
 	const page = await browser.newPage();
+
+	page.setJavaScriptEnabled(options.isJavaScriptEnabled);
 
 	if (options.debug) {
 		page.on('console', message => {
@@ -247,25 +249,22 @@ const captureWebsite = async (url, options) => {
 	}
 
 	const getInjectKey = (ext, value) => isUrl(value) ? 'url' : value.endsWith(`.${ext}`) ? 'path' : 'content';
-	if (options.javascriptEnabled) {
-		if (options.modules) {
-			await Promise.all(options.modules.map(module_ => {
-				return page.addScriptTag({
-					[getInjectKey('js', module_)]: module_,
-					type: 'module'
-				});
-			}));
-		}
 
-		if (options.scripts) {
-			await Promise.all(options.scripts.map(script => {
-				return page.addScriptTag({
-					[getInjectKey('js', script)]: script
-				});
-			}));
-		}
-	} else {
-		await page.setJavaScriptEnabled(options.javascriptEnabled);
+	if (options.modules) {
+		await Promise.all(options.modules.map(module_ => {
+			return page.addScriptTag({
+				[getInjectKey('js', module_)]: module_,
+				type: 'module'
+			});
+		}));
+	}
+
+	if (options.scripts) {
+		await Promise.all(options.scripts.map(script => {
+			return page.addScriptTag({
+				[getInjectKey('js', script)]: script
+			});
+		}));
 	}
 
 	if (options.styles) {

--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ const captureWebsite = async (url, options) => {
 
 	const getInjectKey = (ext, value) => isUrl(value) ? 'url' : value.endsWith(`.${ext}`) ? 'path' : 'content';
 
-	// Reset javascript execution to true for modules
+	// Enable JavaScript again for `modules` and `scripts`.
 	await page.setJavaScriptEnabled(true);
 
 	if (options.modules) {

--- a/index.js
+++ b/index.js
@@ -142,6 +142,7 @@ const captureWebsite = async (url, options) => {
 		debug: false,
 		launchOptions: {},
 		_keepAlive: false,
+		javascriptEnabled: true,
 		...options
 	};
 
@@ -246,22 +247,25 @@ const captureWebsite = async (url, options) => {
 	}
 
 	const getInjectKey = (ext, value) => isUrl(value) ? 'url' : value.endsWith(`.${ext}`) ? 'path' : 'content';
+	if (options.javascriptEnabled) {
+		if (options.modules) {
+			await Promise.all(options.modules.map(module_ => {
+				return page.addScriptTag({
+					[getInjectKey('js', module_)]: module_,
+					type: 'module'
+				});
+			}));
+		}
 
-	if (options.modules) {
-		await Promise.all(options.modules.map(module_ => {
-			return page.addScriptTag({
-				[getInjectKey('js', module_)]: module_,
-				type: 'module'
-			});
-		}));
-	}
-
-	if (options.scripts) {
-		await Promise.all(options.scripts.map(script => {
-			return page.addScriptTag({
-				[getInjectKey('js', script)]: script
-			});
-		}));
+		if (options.scripts) {
+			await Promise.all(options.scripts.map(script => {
+				return page.addScriptTag({
+					[getInjectKey('js', script)]: script
+				});
+			}));
+		}
+	} else {
+		await page.setJavaScriptEnabled(options.javascriptEnabled);
 	}
 
 	if (options.styles) {

--- a/index.js
+++ b/index.js
@@ -250,8 +250,10 @@ const captureWebsite = async (url, options) => {
 
 	const getInjectKey = (ext, value) => isUrl(value) ? 'url' : value.endsWith(`.${ext}`) ? 'path' : 'content';
 
-	// Enable JavaScript again for `modules` and `scripts`.
-	await page.setJavaScriptEnabled(true);
+	if (!options.isJavaScriptEnabled) {
+		// Enable JavaScript again for `modules` and `scripts`.
+		await page.setJavaScriptEnabled(true);
+	}
 
 	if (options.modules) {
 		await Promise.all(options.modules.map(module_ => {

--- a/readme.md
+++ b/readme.md
@@ -238,13 +238,12 @@ Default: `false`
 
 Disable CSS [animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) and [transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition).
 
-##### javascriptEnabled
+##### isJavaScriptEnabled
 
 Type: `boolean`<br>
 Default: `true`
 
-Options to enable javascript execution on the page.
-> nb: If disabled, it also disable `modules` and `scripts`.
+Set JavaScript execution of a website.
 
 ##### modules
 

--- a/readme.md
+++ b/readme.md
@@ -243,7 +243,9 @@ Disable CSS [animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animat
 Type: `boolean`<br>
 Default: `true`
 
-Set JavaScript execution of a website.
+Whether JavaScript on the website should be executed.
+
+This does not affect the `scripts` and `modules` options.
 
 ##### modules
 

--- a/readme.md
+++ b/readme.md
@@ -238,6 +238,14 @@ Default: `false`
 
 Disable CSS [animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) and [transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition).
 
+##### javascriptEnabled
+
+Type: `boolean`<br>
+Default: `true`
+
+Options to enable javascript execution on the page.
+> nb: If disabled, it also disable `modules` and `scripts`.
+
 ##### modules
 
 Type: `string[]`

--- a/test.js
+++ b/test.js
@@ -353,7 +353,7 @@ test('`disableAnimations` option', async t => {
 	await server.close();
 });
 
-test('`isJavaScriptEnabled` option with value false', async t => {
+test('`isJavaScriptEnabled: false` option', async t => {
 	const server = await createTestServer();
 
 	server.get('/', async (request, response) => {
@@ -363,7 +363,7 @@ test('`isJavaScriptEnabled` option with value false', async t => {
 				<script>
 					setTimeout(function() {
 						document.querySelector('div').style.backgroundColor = 'red';
-					}, 1500);
+					}, 500);
 				</script>
 			</body>
 		`);
@@ -383,12 +383,27 @@ test('`isJavaScriptEnabled` option with value false', async t => {
 	await server.close();
 });
 
-test('Still able to execute script even `isJavaScriptEnabled` false', async t => {
+test('`isJavaScriptEnabled: false` works with the `scripts` option', async t => {
 	const pixels = await getPngPixels(await instance(server.url, {
 		width: 100,
 		height: 100,
-		javascriptEnabled: false,
+		isJavaScriptEnabled: false,
 		scripts: [
+			'document.querySelector(\'div\').style.backgroundColor = \'red\';'
+		]
+	}));
+
+	t.is(pixels[0], 255);
+	t.is(pixels[1], 0);
+	t.is(pixels[2], 0);
+});
+
+test('`isJavaScriptEnabled: false` works with the `modules` option', async t => {
+	const pixels = await getPngPixels(await instance(server.url, {
+		width: 100,
+		height: 100,
+		isJavaScriptEnabled: false,
+		modules: [
 			'document.querySelector(\'div\').style.backgroundColor = \'red\';'
 		]
 	}));

--- a/test.js
+++ b/test.js
@@ -353,7 +353,7 @@ test('`disableAnimations` option', async t => {
 	await server.close();
 });
 
-test('`javascrtiptEnabled` option with value false', async t => {
+test('`isJavaScriptEnabled` option with value false', async t => {
 	const server = await createTestServer();
 
 	server.get('/', async (request, response) => {
@@ -373,7 +373,7 @@ test('`javascrtiptEnabled` option with value false', async t => {
 		width: 100,
 		height: 100,
 		delay: 1,
-		javascriptEnabled: false
+		isJavaScriptEnabled: false
 	}));
 
 	t.is(pixels[0], 0);
@@ -383,22 +383,7 @@ test('`javascrtiptEnabled` option with value false', async t => {
 	await server.close();
 });
 
-test('`javascrtiptEnabled` false disable module', async t => {
-	const pixels = await getPngPixels(await instance(server.url, {
-		width: 100,
-		height: 100,
-		javascriptEnabled: false,
-		modules: [
-			'document.querySelector(\'div\').style.backgroundColor = \'red\';'
-		]
-	}));
-
-	t.is(pixels[0], 0);
-	t.is(pixels[1], 0);
-	t.is(pixels[2], 0);
-});
-
-test('`javascrtiptEnabled` false disable script', async t => {
+test('Still able to execute script even `isJavaScriptEnabled` false', async t => {
 	const pixels = await getPngPixels(await instance(server.url, {
 		width: 100,
 		height: 100,
@@ -408,7 +393,7 @@ test('`javascrtiptEnabled` false disable script', async t => {
 		]
 	}));
 
-	t.is(pixels[0], 0);
+	t.is(pixels[0], 255);
 	t.is(pixels[1], 0);
 	t.is(pixels[2], 0);
 });

--- a/test.js
+++ b/test.js
@@ -353,6 +353,66 @@ test('`disableAnimations` option', async t => {
 	await server.close();
 });
 
+test('`javascrtiptEnabled` option with value false', async t => {
+	const server = await createTestServer();
+
+	server.get('/', async (request, response) => {
+		response.end(`
+			<body style="margin: 0;">
+				<div style="background-color: black; width: 100px; height: 100px;"></div>
+				<script>
+					setTimeout(function() {
+						document.querySelector('div').style.backgroundColor = 'red';
+					}, 1500);
+				</script>
+			</body>
+		`);
+	});
+
+	const pixels = await getPngPixels(await instance(server.url, {
+		width: 100,
+		height: 100,
+		delay: 1,
+		javascriptEnabled: false
+	}));
+
+	t.is(pixels[0], 0);
+	t.is(pixels[1], 0);
+	t.is(pixels[2], 0);
+
+	await server.close();
+});
+
+test('`javascrtiptEnabled` false disable module', async t => {
+	const pixels = await getPngPixels(await instance(server.url, {
+		width: 100,
+		height: 100,
+		javascriptEnabled: false,
+		modules: [
+			'document.querySelector(\'div\').style.backgroundColor = \'red\';'
+		]
+	}));
+
+	t.is(pixels[0], 0);
+	t.is(pixels[1], 0);
+	t.is(pixels[2], 0);
+});
+
+test('`javascrtiptEnabled` false disable script', async t => {
+	const pixels = await getPngPixels(await instance(server.url, {
+		width: 100,
+		height: 100,
+		javascriptEnabled: false,
+		scripts: [
+			'document.querySelector(\'div\').style.backgroundColor = \'red\';'
+		]
+	}));
+
+	t.is(pixels[0], 0);
+	t.is(pixels[1], 0);
+	t.is(pixels[2], 0);
+});
+
 test('`modules` option - inline', async t => {
 	const pixels = await getPngPixels(await instance(server.url, {
 		width: 100,


### PR DESCRIPTION
Fixes #25 

# Summary

🦄 

Add new options `javascriptEnabled` to control javascript execution. The parameters named as `javascriptEnabled` to [match puppeteer](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetjavascriptenabledenabled) options


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#25: Add `{javascript: false}` option](https://issuehunt.io/repos/169625338/issues/25)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->