### PR TITLE
Add `darkMode` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -225,6 +225,13 @@ declare namespace captureWebsite {
 		readonly debug?: boolean;
 
 		/**
+		Emulate preference of dark color scheme [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
+
+		@default false
+		*/
+		readonly darkMode?: boolean;
+
+		/**
 		Options passed to [`puppeteer.launch()`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
 
 		Note: Some of the launch options are overridden by the `debug` option.

--- a/index.js
+++ b/index.js
@@ -139,6 +139,7 @@ const captureWebsite = async (input, options) => {
 		timeout: 60, // The Puppeteer default of 30 is too short
 		delay: 0,
 		debug: false,
+		darkMode: false,
 		launchOptions: {},
 		_keepAlive: false,
 		isJavaScriptEnabled: true,
@@ -229,6 +230,11 @@ const captureWebsite = async (input, options) => {
 
 		await page.emulate(devices[options.emulateDevice]);
 	}
+
+	await page.emulateMediaFeatures([{
+		name: 'prefers-color-scheme',
+		value: options.darkMode ? 'dark' : 'light'
+	}]);
 
 	await page[isHTMLContent ? 'setContent' : 'goto'](input, {
 		timeout: timeoutInSeconds,

--- a/readme.md
+++ b/readme.md
@@ -421,6 +421,13 @@ Show the browser window so you can see what it's doing, redirect page console ou
 
 Note: This overrides `launchOptions` with `{headless: false, slowMo: 100}`.
 
+##### darkMode
+
+Type: `boolean`<br>
+Default: `false`
+
+Emulate preference of dark color scheme [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
+
 ##### launchOptions
 
 Type: `object`<br>

--- a/test.js
+++ b/test.js
@@ -698,3 +698,44 @@ test('handle redirects', async t => {
 
 	await server.close();
 });
+
+test('`darkMode` option', async t => {
+	const server = await createTestServer();
+
+	server.get('/', (request, response) => {
+		response.end(`
+		<html>
+			<head>
+				<style>
+					body {
+						background: white;
+						width: 100px;
+						height: 100px;
+					}
+					@media (prefers-color-scheme: dark) {
+						body { background: black; }
+					}
+				</style>
+			</head>
+			<body></body>
+		</html>
+		`);
+	});
+
+	const pixels = await getPngPixels(await instance(server.url, {
+		width: 100,
+		height: 100
+	}));
+
+	t.is(pixels[0], 255);
+
+	const pixels2 = await getPngPixels(await instance(server.url, {
+		width: 100,
+		height: 100,
+		darkMode: true
+	}));
+
+	t.is(pixels2[0], 0);
+
+	await server.close();
+});


### PR DESCRIPTION
Closes #36

Regarding `capture-website-cli`  - changes will be added after this PR is approved to minimize potential fixes.

Also, one question regarding TODO comment:
```
// TODO: Add more events from https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#event-requestfailed
```
Which events are suitable for `debug` mode?
I've added `requestfailed`. I was thinking about adding `request` but for some cases that would produce huge amount of logs.