### PR TITLE
Wait for lazy loaded elements when using the `fullPage` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,9 +129,7 @@ const parseCookie = (url, cookie) => {
 	return ret;
 };
 
-const imagesHaveLoaded = () => {
-	return [...document.images].map(i => i.complete);
-};
+const imagesHaveLoaded = () => [...document.images].map(element => element.complete);
 
 const captureWebsite = async (input, options) => {
 	options = {

--- a/index.js
+++ b/index.js
@@ -125,6 +125,10 @@ const parseCookie = (url, cookie) => {
 	ret.name = ret.key;
 	delete ret.key;
 
+	if (ret.expires) {
+		ret.expires = Math.floor(new Date(ret.expires) / 1000);
+	}
+
 	return ret;
 };
 

--- a/index.js
+++ b/index.js
@@ -332,7 +332,7 @@ const captureWebsite = async (input, options) => {
 
 		// Scroll one viewport at a time, pausing to let content load
 		const viewportHeight = viewportOptions.height;
-		let viewportIncr = 0;
+		let viewportIncrement = 0;
 		while (viewportIncr + viewportHeight < ppHeight) {
 			/* eslint-disable no-await-in-loop */
 			await page.evaluate(_viewportHeight => {

--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ const captureWebsite = async (input, options) => {
 		const viewportHeight = viewportOptions.height;
 		let viewportIncrement = 0;
 		while (viewportIncrement + viewportHeight < bodyBoundingHeight) {
-			const navigationPromise = page.waitForNavigation();
+			const navigationPromise = page.waitForNavigation({waitUntil: 'networkidle0'});
 			/* eslint-disable no-await-in-loop */
 			await page.evaluate(_viewportHeight => {
 				/* eslint-disable no-undef */

--- a/index.js
+++ b/index.js
@@ -355,7 +355,7 @@ const captureWebsite = async (input, options) => {
 		});
 
 		// Some extra delay to let images load
-		await page.waitForFunction(imagesHaveLoaded, {timeout: 30});
+		await page.waitForFunction(imagesHaveLoaded, {timeout: 60});
 	}
 
 	const buffer = await page.screenshot(screenshotOptions);

--- a/index.js
+++ b/index.js
@@ -129,6 +129,10 @@ const parseCookie = (url, cookie) => {
 	return ret;
 };
 
+const imagesHaveLoaded = () => {
+	return [...document.images].map(i => i.complete);
+};
+
 const captureWebsite = async (input, options) => {
 	options = {
 		inputType: 'url',
@@ -351,7 +355,7 @@ const captureWebsite = async (input, options) => {
 		});
 
 		// Some extra delay to let images load
-		await sleep(100);
+		await page.waitForFunction(imagesHaveLoaded, {timeout: 30});
 	}
 
 	const buffer = await page.screenshot(screenshotOptions);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "capture-website",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "Capture screenshots of websites",
 	"license": "MIT",
 	"repository": "sindresorhus/capture-website",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "capture-website",
-	"version": "0.8.1",
+	"version": "0.8.0",
 	"description": "Capture screenshots of websites",
 	"license": "MIT",
 	"repository": "sindresorhus/capture-website",

--- a/test.js
+++ b/test.js
@@ -158,31 +158,14 @@ test('`fullPage` option', async t => {
 
 test('`fullPage` option - lazyloading', async t => {
 	const server = await createTestServer();
+	const imageAmount = 50;
 
 	server.get('/', async (request, response) => {
 		response.end(`
 			<body>
-				<div style="display: grid; grid-template-columns: repeat( auto-fill, minmax(150px, 1fr) );" id="grid"></div>
-				<script>
-					const numItemsToGenerate = 250; //how many gallery items you want on the screen
-					const numImagesAvailable = 1100; //how many total images are in the collection you are pulling from
-					const imageWidth = 150; //your desired image width in pixels
-					const imageHeight = 150; //desired image height in pixels
-					const collectionID = 9717149; //the collection ID from the original url
-					function renderGalleryItem(randomNumber){
-					fetch('https://source.unsplash.com/collection/'+collectionID+'/'+imageWidth+'x'+imageHeight+'/?sig='+randomNumber)
-					.then((response)=> {
-						let galleryItem = document.createElement('div');
-						galleryItem.classList.add('gallery-item');
-						galleryItem.innerHTML = '<img class="gallery-image" src="'+response.url+'" alt="gallery image" loading="lazy" />';
-						document.getElementById('grid').appendChild(galleryItem);
-					})
-					}
-					for(let i=0;i<numItemsToGenerate;i++){
-					let randomImageIndex = Math.floor(Math.random() * numImagesAvailable);
-					renderGalleryItem(randomImageIndex);
-					}
-				</script>
+				<div style="display: grid; grid-template-columns: repeat( auto-fill, minmax(150px, 1fr) );">
+				   ${Array(imageAmount).fill().map(image => `<img src="https://picsum.photos/150/150?random=${image}" loading="lazy" />`).join('')}
+				</div>
 			</body>
 		`);
 	});

--- a/test.js
+++ b/test.js
@@ -164,7 +164,7 @@ test('`fullPage` option - lazy loading', async t => {
 		response.end(`
 			<body>
 				<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));">
-				   ${[...new Array(imageCount).keys()].map(image => `<img src="https://picsum.photos/150/150?random=${image}" loading="lazy">`).join('')}
+					${[...new Array(imageCount).keys()].map(image => `<img src="https://picsum.photos/150/150?random=${image}" loading="lazy">`).join('')}
 				</div>
 			</body>
 		`);

--- a/test.js
+++ b/test.js
@@ -156,15 +156,15 @@ test('`fullPage` option', async t => {
 	t.true(size.height > 100);
 });
 
-test('`fullPage` option - lazyloading', async t => {
+test('`fullPage` option - lazy loading', async t => {
 	const server = await createTestServer();
-	const imageAmount = 50;
+	const imageCount = 50;
 
 	server.get('/', async (request, response) => {
 		response.end(`
 			<body>
-				<div style="display: grid; grid-template-columns: repeat( auto-fill, minmax(150px, 1fr) );">
-				   ${[...new Array(imageAmount).keys()].map(image => `<img src="https://picsum.photos/150/150?random=${image}" loading="lazy" />`).join('')}
+				<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));">
+				   ${[...new Array(imageCount).keys()].map(image => `<img src="https://picsum.photos/150/150?random=${image}" loading="lazy">`).join('')}
 				</div>
 			</body>
 		`);

--- a/test.js
+++ b/test.js
@@ -156,6 +156,48 @@ test('`fullPage` option', async t => {
 	t.true(size.height > 100);
 });
 
+test('`fullPage` option - lazyloading', async t => {
+	const server = await createTestServer();
+
+	server.get('/', async (request, response) => {
+		response.end(`
+			<body>
+				<div style="display: grid; grid-template-columns: repeat( auto-fill, minmax(150px, 1fr) );" id="grid"></div>
+				<script>
+					const numItemsToGenerate = 250; //how many gallery items you want on the screen
+					const numImagesAvailable = 1100; //how many total images are in the collection you are pulling from
+					const imageWidth = 150; //your desired image width in pixels
+					const imageHeight = 150; //desired image height in pixels
+					const collectionID = 9717149; //the collection ID from the original url
+					function renderGalleryItem(randomNumber){
+					fetch('https://source.unsplash.com/collection/'+collectionID+'/'+imageWidth+'x'+imageHeight+'/?sig='+randomNumber)
+					.then((response)=> {
+						let galleryItem = document.createElement('div');
+						galleryItem.classList.add('gallery-item');
+						galleryItem.innerHTML = '<img class="gallery-image" src="'+response.url+'" alt="gallery image" loading="lazy" />';
+						document.getElementById('grid').appendChild(galleryItem);
+					})
+					}
+					for(let i=0;i<numItemsToGenerate;i++){
+					let randomImageIndex = Math.floor(Math.random() * numImagesAvailable);
+					renderGalleryItem(randomImageIndex);
+					}
+				</script>
+			</body>
+		`);
+	});
+
+	const size = imageSize(await instance(server.url, {
+		width: 200,
+		height: 300,
+		scaleFactor: 1,
+		fullPage: true
+	}));
+
+	t.is(size.width, 200);
+	t.true(size.height > 150);
+});
+
 test('`timeout` option', async t => {
 	const server = await createTestServer();
 

--- a/test.js
+++ b/test.js
@@ -164,7 +164,7 @@ test('`fullPage` option - lazyloading', async t => {
 		response.end(`
 			<body>
 				<div style="display: grid; grid-template-columns: repeat( auto-fill, minmax(150px, 1fr) );">
-				   ${Array(imageAmount).fill().map(image => `<img src="https://picsum.photos/150/150?random=${image}" loading="lazy" />`).join('')}
+				   ${[...new Array(imageAmount).keys()].map(image => `<img src="https://picsum.photos/150/150?random=${image}" loading="lazy" />`).join('')}
 				</div>
 			</body>
 		`);


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/capture-website/issues/28

Based on [the following walkthrough](https://wiki.zegnat.net/cache/?md5=f7ce4fd73de0ac41f15ea708b4c8f20f) initially documented by a now deprecated ("Note: Service has been discontinued, this website remains for archival purposes") platform. Thanks to its wiki's author for documenting.

![i failed to archive.org the site ... wiki zegnat net_cache__md5=f7ce4fd73de0ac41f15ea708b4c8f20f](https://user-images.githubusercontent.com/48886164/68802669-b8fee500-0634-11ea-89d1-ae74c43aa62f.png)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#28: Wait for lazy loaded elements when using the `fullPage` option](https://issuehunt.io/repos/169625338/issues/28)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->