### PR TITLE
Changed image waiting method on fullPage option, +TravisCI fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,8 +119,6 @@ const parseCookie = (url, cookie) => {
 	return returnValue;
 };
 
-const imagesHaveLoaded = () => [...document.images].map(element => element.complete);
-
 const captureWebsite = async (input, options) => {
 	options = {
 		inputType: 'url',
@@ -340,15 +338,20 @@ const captureWebsite = async (input, options) => {
 			viewportIncrement += viewportHeight;
 		}
 
-		// Scroll back to top
+		// Wait for images to be complete and scroll back to top 
 		await page.evaluate(_ => {
+			const selectors = Array.from(document.images);
+			await Promise.all(selectors.map(img => {
+				if (img.complete) return;
+				return new Promise((resolve, reject) => {
+					img.addEventListener('load', resolve);
+					img.addEventListener('error', reject);
+				});
+			}));
 			/* eslint-disable no-undef */
 			window.scrollTo(0, 0);
 			/* eslint-enable no-undef */
 		});
-
-		// Some extra delay to let images load
-		await page.waitForFunction(imagesHaveLoaded, {timeout: 60});
 	}
 
 	const buffer = await page.screenshot(screenshotOptions);

--- a/index.js
+++ b/index.js
@@ -345,7 +345,7 @@ const captureWebsite = async (input, options) => {
 				if (img.complete) {
 					return;
 				}
-				
+
 				return new Promise((resolve, reject) => {
 					img.addEventListener('load', resolve);
 					img.addEventListener('error', reject);

--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ const captureWebsite = async (input, options) => {
 		}
 
 		// Wait for images to be complete and scroll back to top 
-		await page.evaluate(_ => {
+		await page.evaluate(async _ => {
 			const selectors = Array.from(document.images);
 			await Promise.all(selectors.map(img => {
 				if (img.complete) return;

--- a/index.js
+++ b/index.js
@@ -342,9 +342,10 @@ const captureWebsite = async (input, options) => {
 		await page.evaluate(async _ => {
 			const selectors = [...document.images];
 			await Promise.all(selectors.map(img => {
-				if (img.complete) { 
+				if (img.complete) {
 					return;
 				}
+				
 				return new Promise((resolve, reject) => {
 					img.addEventListener('load', resolve);
 					img.addEventListener('error', reject);

--- a/index.js
+++ b/index.js
@@ -329,9 +329,8 @@ const captureWebsite = async (input, options) => {
 			const navigationPromise = page.waitForNavigation({waitUntil: 'networkidle0'});
 			/* eslint-disable no-await-in-loop */
 			await page.evaluate(_viewportHeight => {
-				/* eslint-disable no-undef */
+				/* eslint-disable-next-line no-undef */
 				window.scrollBy(0, _viewportHeight);
-				/* eslint-enable no-undef */
 			}, viewportHeight);
 			await navigationPromise;
 			/* eslint-enable no-await-in-loop */
@@ -346,14 +345,14 @@ const captureWebsite = async (input, options) => {
 					return;
 				}
 
+				// eslint-disable-next-line no-unused-vars
 				return new Promise((resolve, reject) => {
-					img.addEventListener('load', resolve);
-					img.addEventListener('error', reject);
+					promisify(img.addEventListener)('load');
+					promisify(img.addEventListener)('error');
 				});
 			}));
-			/* eslint-disable no-undef */
+			/* eslint-disable-next-line no-undef */
 			window.scrollTo(0, 0);
-			/* eslint-enable no-undef */
 		});
 	}
 

--- a/index.js
+++ b/index.js
@@ -338,11 +338,13 @@ const captureWebsite = async (input, options) => {
 			viewportIncrement += viewportHeight;
 		}
 
-		// Wait for images to be complete and scroll back to top 
+		// Wait for images to be complete and scroll back to top
 		await page.evaluate(async _ => {
-			const selectors = Array.from(document.images);
+			const selectors = [...document.images];
 			await Promise.all(selectors.map(img => {
-				if (img.complete) return;
+				if (img.complete) { 
+					return;
+				}
 				return new Promise((resolve, reject) => {
 					img.addEventListener('load', resolve);
 					img.addEventListener('error', reject);

--- a/index.js
+++ b/index.js
@@ -319,20 +319,18 @@ const captureWebsite = async (input, options) => {
 	if (screenshotOptions.fullPage) {
 		// Get the height of the rendered page
 		const bodyHandle = await page.$('body');
-		const bodyBoundingHeight = await bodyHandle.boundingBox();
+		const {height: bodyBoundingHeight} = await bodyHandle.boundingBox();
 		await bodyHandle.dispose();
 
 		// Scroll one viewport at a time, pausing to let content load
 		const viewportHeight = viewportOptions.height;
 		let viewportIncrement = 0;
 		while (viewportIncrement + viewportHeight < bodyBoundingHeight) {
-			const navigationPromise = page.waitForNavigation({waitUntil: 'networkidle0'});
 			/* eslint-disable no-await-in-loop */
 			await page.evaluate(_viewportHeight => {
 				/* eslint-disable-next-line no-undef */
 				window.scrollBy(0, _viewportHeight);
 			}, viewportHeight);
-			await navigationPromise;
 			/* eslint-enable no-await-in-loop */
 			viewportIncrement += viewportHeight;
 		}

--- a/index.js
+++ b/index.js
@@ -338,16 +338,12 @@ const captureWebsite = async (input, options) => {
 		// Wait for images to be complete and scroll back to top
 		await page.evaluate(async _ => {
 			const selectors = [...document.images];
-			await Promise.all(selectors.map(img => {
-				if (img.complete) {
-					return;
-				}
 
-				// eslint-disable-next-line no-unused-vars
-				return new Promise((resolve, reject) => {
-					promisify(img.addEventListener)('load');
-					promisify(img.addEventListener)('error');
-				});
+			await Promise.all(selectors.filter(img => !img.complete).map(img => {
+				return Promise.race([
+					promisify(img.addEventListener)('load'),
+					promisify(img.addEventListener)('error')
+				]);
 			}));
 			/* eslint-disable-next-line no-undef */
 			window.scrollTo(0, 0);


### PR DESCRIPTION
https://github.com/sindresorhus/capture-website/pull/40#discussion_r413583308

Trying to fix last reports not running as well as fixing out what was pointed in the discussion above. The function for `fullPage` on lazy loading elements checks for pending images at the end of the conditional block by using a waitForFunction, when it could've been improved to the code currently PR'd.