### PR TITLE
Fix `removeElements` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ const captureWebsite = async (input, options) => {
 
 	if (options.removeElements) {
 		await page.addStyleTag({
-			content: `${options.removeElements.join(' ')} { display: none !important; }`
+			content: `${options.removeElements.join(', ')} { display: none !important; }`
 		});
 	}
 


### PR DESCRIPTION
The error that occurs when multiple elements are designated was corrected.