### PR TITLE
Add `inset` option

### DIFF
--- a/fixtures/inset-option.html
+++ b/fixtures/inset-option.html
@@ -1,0 +1,32 @@
+<html>
+	<head>
+		<style>
+			* {
+				margin: 0;
+				padding: 0;
+				box-sizing: border-box;
+			}
+
+			body {
+				background: black;
+				padding: 10px;
+			}
+
+			.header {
+				background: red;
+				height: 20px;
+				width: 100%
+			}
+
+			.content {
+				background: white;
+				height: 500px;
+				width: 100%;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="header"></div>
+		<div class="content"></div>
+	</body>
+</html>

--- a/index.d.ts
+++ b/index.d.ts
@@ -240,16 +240,33 @@ declare namespace captureWebsite {
 		readonly launchOptions?: LaunchOptions;
 
 		/**
-		Used to modify the bounding box of the screenshot.
-		Positive values (e.g. `inset: { top: 10 }`) will decrease the size of the screenshot.
+		Accepts an object `{ top?: number; right?: number; bottom?: number; left?: number }` or a `number` as a shorthand for all directions.
+
+		Modifies the bounding box of the screenshot.
+		Positive values (e.g. `inset: 10`) will decrease the size of the screenshot.
 		Negative values (e.g. `inset: { left: -10 }`) will increase the size of the screenshot.
 
-		When the `width` or `height` of the box is equal to `0` an error is thrown.
+		Note: This option is ignored if option `fullPage` is set to `true`. Can be combined with `element` option.
+		Note: When the `width` or `height` of the screenshot is equal to `0` an error is thrown.
 
-		Note: Ignored when `fullPage` option is set to `true`. Can be combined with "element" option.
+		Example: Include 10 pixels around element.
+
+		```js
+		(async () => {
+			await captureWebsite.file('index.html', 'screenshot.png', { element: '.logo', inset: -10 });
+		})();
+		```
+
+		Example: Ignore 15 pixels from top of the viewport.
+		```js
+		(async () => {
+			await captureWebsite.file('index.html', 'screenshot.png', { inset: { top: 15 } });
+		})();
+		```
+
 		@default 0
 		*/
-		readonly inset?: InsetOptions;
+		readonly inset?: number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>;
 	}
 
 	interface FileOptions extends Options {
@@ -260,8 +277,6 @@ declare namespace captureWebsite {
 		*/
 		readonly overwrite?: boolean;
 	}
-
-	type InsetOptions = number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>;
 }
 
 declare const captureWebsite: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -240,31 +240,38 @@ declare namespace captureWebsite {
 		readonly launchOptions?: LaunchOptions;
 
 		/**
-		Accepts an object `{ top?: number; right?: number; bottom?: number; left?: number }` or a `number` as a shorthand for all directions.
+		Inset the bounding box of the screenshot.
+		
+		@default 0
 
-		Modifies the bounding box of the screenshot.
-		Positive values (e.g. `inset: 10`) will decrease the size of the screenshot.
-		Negative values (e.g. `inset: { left: -10 }`) will increase the size of the screenshot.
+		Accepts an object `{top?: number; right?: number; bottom?: number; left?: number}` or a `number` as a shorthand for all directions.
 
-		Note: This option is ignored if option `fullPage` is set to `true`. Can be combined with `element` option.
+		Positive values, for example `inset: 10`, will decrease the size of the screenshot.
+		Negative values, for example `inset: {left: -10}`, will increase the size of the screenshot.
+
+		Note: This option is ignored if the `fullPage` option is set to `true`. Can be combined with the `element` option.
 		Note: When the `width` or `height` of the screenshot is equal to `0` an error is thrown.
 
-		Example: Include 10 pixels around element.
+		Example: Include 10 pixels around the element.
 
-		```js
-		(async () => {
-			await captureWebsite.file('index.html', 'screenshot.png', { element: '.logo', inset: -10 });
-		})();
+		@example
+		```
+		await captureWebsite.file('index.html', 'screenshot.png', {
+			element: '.logo',
+			inset: -10
+		});
 		```
 
-		Example: Ignore 15 pixels from top of the viewport.
-		```js
-		(async () => {
-			await captureWebsite.file('index.html', 'screenshot.png', { inset: { top: 15 } });
-		})();
-		```
+		Example: Ignore 15 pixels from the top of the viewport.
 
-		@default 0
+		@example
+		```
+		await captureWebsite.file('index.html', 'screenshot.png', {
+			inset: {
+				top: 15
+			}
+		});
+		```
 		*/
 		readonly inset?: number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -244,7 +244,7 @@ declare namespace captureWebsite {
 		Positive values (e.g. `inset: { top: 10 }`) will decrease the size of the screenshot.
 		Negative values (e.g. `inset: { left: -10 }`) will increase the size of the screenshot.
 
-		When the `width` or `height` of the box are equal to `0` an error is thrown.
+		When the `width` or `height` of the box is equal to `0` an error is thrown.
 
 		Note: Ignored when `fullPage` option is set to `true`. Can be combined with "element" option.
 		@default 0

--- a/index.d.ts
+++ b/index.d.ts
@@ -238,6 +238,18 @@ declare namespace captureWebsite {
 		@default {}
 		*/
 		readonly launchOptions?: LaunchOptions;
+
+		/**
+		Used to modify the bounding box of the screenshot.
+		Positive values (e.g. `inset: { top: 10 }`) will decrease the size of the screenshot.
+		Negative values (e.g. `inset: { left: -10 }`) will increase the size of the screenshot.
+
+		When the `width` or `height` of the box are equal to `0` an error is thrown.
+
+		Note: Ignored when `fullPage` option is set to `true`. Can be combined with "element" option.
+		@default 0
+		*/
+		readonly inset?: InsetOptions;
 	}
 
 	interface FileOptions extends Options {
@@ -248,6 +260,8 @@ declare namespace captureWebsite {
 		*/
 		readonly overwrite?: boolean;
 	}
+
+	type InsetOptions = number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>;
 }
 
 declare const captureWebsite: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -241,7 +241,7 @@ declare namespace captureWebsite {
 
 		/**
 		Inset the bounding box of the screenshot.
-		
+
 		@default 0
 
 		Accepts an object `{top?: number; right?: number; bottom?: number; left?: number}` or a `number` as a shorthand for all directions.

--- a/index.js
+++ b/index.js
@@ -383,7 +383,7 @@ const captureWebsite = async (input, options) => {
 		if (width === 0 || height === 0) {
 			await page.close();
 
-			throw new Error('When using "clip" option the width or height of the screenshot cannot be equal to 0');
+			throw new Error('When using the `clip` option, the width or height of the screenshot cannot be equal to 0.');
 		}
 
 		screenshotOptions.clip = {x, y, width, height};

--- a/readme.md
+++ b/readme.md
@@ -427,30 +427,34 @@ Emulate preference of dark color scheme ([`prefers-color-scheme`](https://develo
 ##### inset
 
 Type: `object | number`\
-Default: 0
+Default: `0`
 
-Accepts an object `{ top?: number; right?: number; bottom?: number; left?: number }` or a `number` as a shorthand for all directions.
+Accepts an object `{top?: number; right?: number; bottom?: number; left?: number}` or a `number` as a shorthand for all directions.
 
 Modifies the bounding box of the screenshot.
-Positive values (e.g. `inset: 10`) will decrease the size of the screenshot.
-Negative values (e.g. `inset: { left: -10 }`) will increase the size of the screenshot.
+Positive values, for example `inset: 10`, will decrease the size of the screenshot.
+Negative values, for example `inset: {left: -10}`, will increase the size of the screenshot.
 
-Note: This option is ignored if option `fullPage` is set to `true`. Can be combined with `element` option.
+Note: This option is ignored if the `fullPage` option is set to `true`. Can be combined with the `element` option.
 Note: When the `width` or `height` of the screenshot is equal to `0` an error is thrown.
 
-Example: Include 10 pixels around element.
+Example: Include 10 pixels around the element.
 
 ```js
-(async () => {
-	await captureWebsite.file('index.html', 'screenshot.png', { element: '.logo', inset: -10 });
-})();
+await captureWebsite.file('index.html', 'screenshot.png', {
+	element: '.logo',
+	inset: -10
+});
 ```
 
-Example: Ignore 15 pixels from top of the viewport.
+Example: Ignore 15 pixels from the top of the viewport.
+
 ```js
-(async () => {
-	await captureWebsite.file('index.html', 'screenshot.png', { inset: { top: 15 } });
-})();
+await captureWebsite.file('index.html', 'screenshot.png', {
+	inset: {
+		top: 15
+	}
+});
 ```
 
 ##### launchOptions

--- a/readme.md
+++ b/readme.md
@@ -436,7 +436,7 @@ Positive values (e.g. `inset: 10`) will decrease the size of the screenshot.
 Negative values (e.g. `inset: { left: -10 }`) will increase the size of the screenshot.
 
 Note: This option is ignored if option `fullPage` is set to `true`. Can be combined with `element` option.
-Note: When the `width` or `height` of the screenshot are equal to `0` an error is thrown.
+Note: When the `width` or `height` of the screenshot is equal to `0` an error is thrown.
 
 Example: Include 10 pixels around element.
 

--- a/readme.md
+++ b/readme.md
@@ -424,6 +424,35 @@ Default: `false`
 
 Emulate preference of dark color scheme ([`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)).
 
+##### inset
+
+Type: `object | number`
+Default: 0
+
+Accepts an object `{ top?: number; right?: number; bottom?: number; left?: number }` or a `number` as a shorthand for all directions.
+
+Modifies the bounding box of the screenshot.
+Positive values (e.g. `inset: 10`) will decrease the size of the screenshot.
+Negative values (e.g. `inset: { left: -10 }`) will increase the size of the screenshot.
+
+Note: This option is ignored if option `fullPage` is set to `true`. Can be combined with `element` option.
+Note: When the `width` or `height` of the screenshot are equal to `0` an error is thrown.
+
+Example: Include 10 pixels around element.
+
+```js
+(async () => {
+	await captureWebsite.file('index.html', 'screenshot.png', { element: '.logo', inset: -10 });
+})();
+```
+
+Example: Ignore 15 pixels from top of the viewport.
+```js
+(async () => {
+	await captureWebsite.file('index.html', 'screenshot.png', { inset: { top: 15 } });
+})();
+```
+
 ##### launchOptions
 
 Type: `object`\

--- a/readme.md
+++ b/readme.md
@@ -426,7 +426,7 @@ Emulate preference of dark color scheme ([`prefers-color-scheme`](https://develo
 
 ##### inset
 
-Type: `object | number`
+Type: `object | number`\
 Default: 0
 
 Accepts an object `{ top?: number; right?: number; bottom?: number; left?: number }` or a `number` as a shorthand for all directions.

--- a/readme.md
+++ b/readme.md
@@ -429,9 +429,10 @@ Emulate preference of dark color scheme ([`prefers-color-scheme`](https://develo
 Type: `object | number`\
 Default: `0`
 
+Inset the bounding box of the screenshot.
+
 Accepts an object `{top?: number; right?: number; bottom?: number; left?: number}` or a `number` as a shorthand for all directions.
 
-Modifies the bounding box of the screenshot.
 Positive values, for example `inset: 10`, will decrease the size of the screenshot.
 Negative values, for example `inset: {left: -10}`, will increase the size of the screenshot.
 

--- a/test.js
+++ b/test.js
@@ -776,61 +776,61 @@ test('`inset` option', async t => {
 		width: 100,
 		height: 100
 	};
-	// Options "inset" and "fullPage" are exclusive.
+	// The `inset` and `fullPage` options are exclusive.
 	// See: https://github.com/puppeteer/puppeteer/blob/e45acce928429d0d1572e16943307a73ebd38d8a/src/common/Page.ts#L1620
-	// In such cases the option "inset" should be ignored.
+	// In such cases, the `inset` option should be ignored.
 	const withFullPageOption = await getPngPixels(await instance(server.url, {
 		...viewportOptions,
 		fullPage: true,
 		inset: 10
 	}));
-	// First pixel should be black, image should have resolution 100x100.
+	// First pixel should be black. Image should have resolution 100x100.
 	t.is(withFullPageOption[0], 0);
 	t.is(withFullPageOption[1], 0);
 	t.is(withFullPageOption[2], 0);
-	t.is(true, withFullPageOption.length / 4 === 100 * 100);
+	t.true(withFullPageOption.length / 4 === 100 * 100);
 
 	// A document with black body with margin 10px containing
-	// two full-width div elements stacked on top of each other.
-	// First div element is red and has height of 20px.
-	// Second div element is white and has height of 500px.
+	// two full-width `div` elements stacked on top of each other.
+	// First `div` element is red and has height of 20px.
+	// Second `div` element is white and has height of 500px.
 	const fixture = 'fixtures/inset-option.html';
 
-	// Option "element" overwrites the "fullPage" option value
-	// therefore should behave as if "fullPage" option was "false".
+	// The `element` option overwrites the `fullPage` option,
+	// therefore should behave as if `fullPage` option was `false`.
 	const withElementOption = await getPngPixels(await instance(fixture, {
 		...viewportOptions,
 		element: 'body',
 		fullPage: true,
 		inset: 10
 	}));
-	// First pixel should be red, image should have resolution 80*520.
+	// First pixel should be red. Image should have resolution 80*520.
 	t.is(withElementOption[0], 255);
 	t.is(withElementOption[1], 0);
 	t.is(withElementOption[2], 0);
-	t.is(true, withElementOption.length / 4 === 80 * 520);
+	t.true(withElementOption.length / 4 === 80 * 520);
 
 	const viewportPixels = await getPngPixels(await instance(fixture, {
 		...viewportOptions,
 		inset: 10
 	}));
 
-	// First pixel should be red, image should have resolution 80x80.
+	// First pixel should be red. Image should have resolution 80x80.
 	t.is(viewportPixels[0], 255);
 	t.is(viewportPixels[1], 0);
 	t.is(viewportPixels[2], 0);
-	t.is(true, viewportPixels.length / 4 === 80 * 80);
+	t.true(viewportPixels.length / 4 === 80 * 80);
 
 	const withTopInset = await getPngPixels(await instance(fixture, {
 		...viewportOptions,
 		inset: {top: 30, left: 10}
 	}));
 
-	// First pixel should be white, the image resolution should be 90x70.
+	// First pixel should be white. The image resolution should be 90x70.
 	t.is(withTopInset[0], 255);
 	t.is(withTopInset[1], 255);
 	t.is(withTopInset[2], 255);
-	t.is(true, withTopInset.length / 4 === 90 * 70);
+	t.true(withTopInset.length / 4 === 90 * 70);
 
 	const withNegativeInset = await getPngPixels(await instance(fixture, {
 		...viewportOptions,
@@ -838,13 +838,13 @@ test('`inset` option', async t => {
 		inset: -10
 	}));
 
-	// First pixel should be black, the image resolution should be 100x40.
+	// First pixel should be black. The image resolution should be 100x40.
 	t.is(withNegativeInset[0], 0);
 	t.is(withNegativeInset[1], 0);
 	t.is(withNegativeInset[2], 0);
-	t.is(true, withNegativeInset.length / 4 === 100 * 40);
+	t.true(withNegativeInset.length / 4 === 100 * 40);
 
-	// Should throw if inset width or height values are 0.
+	// Should throw if `inset` width or height values are 0.
 	await t.throwsAsync(async () => {
 		await instance(fixture, {
 			...viewportOptions,

--- a/test.js
+++ b/test.js
@@ -754,6 +754,8 @@ test('`darkMode` option', async t => {
 	}));
 
 	t.is(pixels[0], 255);
+	t.is(pixels[1], 255);
+	t.is(pixels[2], 255);
 
 	const pixels2 = await getPngPixels(await instance(server.url, {
 		width: 100,
@@ -762,6 +764,91 @@ test('`darkMode` option', async t => {
 	}));
 
 	t.is(pixels2[0], 0);
+	t.is(pixels2[1], 0);
+	t.is(pixels2[2], 0);
 
 	await server.close();
+});
+
+test('`inset` option', async t => {
+	const viewportOptions = {
+		scaleFactor: 1,
+		width: 100,
+		height: 100
+	};
+	// Options "inset" and "fullPage" are exclusive.
+	// See: https://github.com/puppeteer/puppeteer/blob/e45acce928429d0d1572e16943307a73ebd38d8a/src/common/Page.ts#L1620
+	// In such cases the option "inset" should be ignored.
+	const withFullPageOption = await getPngPixels(await instance(server.url, {
+		...viewportOptions,
+		fullPage: true,
+		inset: 10
+	}));
+	// First pixel should be black, image should have resolution 100x100.
+	t.is(withFullPageOption[0], 0);
+	t.is(withFullPageOption[1], 0);
+	t.is(withFullPageOption[2], 0);
+	t.is(true, withFullPageOption.length / 4 === 100 * 100);
+
+	// A document with black body with margin 10px containing
+	// two full-width div elements stacked on top of each other.
+	// First div element is red and has height of 20px.
+	// Second div element is white and has height of 500px.
+	const fixture = 'fixtures/inset-option.html';
+
+	// Option "element" overwrites the "fullPage" option value
+	// therefore should behave as if "fullPage" option was "false".
+	const withElementOption = await getPngPixels(await instance(fixture, {
+		...viewportOptions,
+		element: 'body',
+		fullPage: true,
+		inset: 10
+	}));
+	// First pixel should be red, image should have resolution 80*520.
+	t.is(withElementOption[0], 255);
+	t.is(withElementOption[1], 0);
+	t.is(withElementOption[2], 0);
+	t.is(true, withElementOption.length / 4 === 80 * 520);
+
+	const viewportPixels = await getPngPixels(await instance(fixture, {
+		...viewportOptions,
+		inset: 10
+	}));
+
+	// First pixel should be red, image should have resolution 80x80.
+	t.is(viewportPixels[0], 255);
+	t.is(viewportPixels[1], 0);
+	t.is(viewportPixels[2], 0);
+	t.is(true, viewportPixels.length / 4 === 80 * 80);
+
+	const withTopInset = await getPngPixels(await instance(fixture, {
+		...viewportOptions,
+		inset: {top: 30, left: 10}
+	}));
+
+	// First pixel should be white, the image resolution should be 90x70.
+	t.is(withTopInset[0], 255);
+	t.is(withTopInset[1], 255);
+	t.is(withTopInset[2], 255);
+	t.is(true, withTopInset.length / 4 === 90 * 70);
+
+	const withNegativeInset = await getPngPixels(await instance(fixture, {
+		...viewportOptions,
+		element: '.header',
+		inset: -10
+	}));
+
+	// First pixel should be black, the image resolution should be 100x40.
+	t.is(withNegativeInset[0], 0);
+	t.is(withNegativeInset[1], 0);
+	t.is(withNegativeInset[2], 0);
+	t.is(true, withNegativeInset.length / 4 === 100 * 40);
+
+	// Should throw if inset width or height values are 0.
+	await t.throwsAsync(async () => {
+		await instance(fixture, {
+			...viewportOptions,
+			inset: 50
+		});
+	});
 });


### PR DESCRIPTION
Adds `inset` option as defined in https://github.com/sindresorhus/capture-website/issues/8

Summary: `inset` option changes the size of the screenshot by using [`clip`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagescreenshotoptions) option from puppeteer API.
If the `element` option is also provided, then the `element` will become the "center of attention" instead of the viewbox (window).
If the `fullPage` option is provided with value `true`, then the `inset` option is ignored ([source](https://github.com/puppeteer/puppeteer/blob/e45acce928429d0d1572e16943307a73ebd38d8a/src/common/Page.ts#L1620)).

It will also throw an Error when the resulting `width` or `height` of the screenshot (`clip` option) is equal to `0`. [source](https://github.com/puppeteer/puppeteer/blob/e45acce928429d0d1572e16943307a73ebd38d8a/src/common/Page.ts#L1645).

Closes https://github.com/sindresorhus/capture-website/issues/8

Note: the comments in the test may be unnecessary but I hope they will reduce time needed to figure out what are the expected values there.

Note: The `capture-website-cli` work will be added once this PR is reviewed and any open points are adressed/fixed.

Edit: To anyone willing to continue - it's pretty much complete, I won't have time to finish this (add this option to cli lib) in the following months.

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#8: Add `inset` option](https://issuehunt.io/repos/169625338/issues/8)
---
</details>
<!-- /Issuehunt content-->