### PR TITLE
Fix `scrollToElement` option when element is not in view

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const scrollToElement = (element, options) => {
 	const parent = findScrollParent(element);
 
 	if (parent !== undefined) {
-		parent.scrollIntoView(true)
+		parent.scrollIntoView(true);
 		parent.scrollTo(offset.x, offset.y);
 	}
 };

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ const scrollToElement = (element, options) => {
 	const parent = findScrollParent(element);
 
 	if (parent !== undefined) {
+		parent.scrollIntoView(true)
 		parent.scrollTo(offset.x, offset.y);
 	}
 };


### PR DESCRIPTION
In #47 @krnik commented

> Before we try to scroll the parentElement we should also scroll the body so that the parent element is visible. 
> Currently we try to scroll elements that are not scrollable and/or outside of the viewport.
> 
> `parentElement.scrollIntoView(true)` something like this is missing

I tried this and indeed that made scrolling to an `id` and a `class` work.

Fixes #47