### PR TITLE
Move @types/puppeteer from dev dependencies to normal dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
 		"jpg"
 	],
 	"dependencies": {
+		"@types/puppeteer": "^3.0.2",
 		"file-url": "^3.0.0",
 		"puppeteer": "^5.3.1",
 		"tough-cookie": "^4.0.0"
 	},
 	"devDependencies": {
-		"@types/puppeteer": "^3.0.2",
 		"ava": "^2.4.0",
 		"create-test-server": "^3.0.1",
 		"delay": "^4.4.0",


### PR DESCRIPTION
in order to use the types in the `launchOptions` property, `@types/puppeteer` needs to be installed making it more suited as a normal dependency