### PR TITLE
Perform `beforeScreenshot` operation before determining element bounding rectangle

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -208,8 +208,10 @@ declare namespace captureWebsite {
 		readonly authentication?: Authentication;
 
 		/**
-		The specified function is called right before the screenshot is captured and before the bounding rectangle of `options.element` is calculated.
-		It gives you a lot of power to do custom stuff. The function can be async.
+		The specified function is called right before the screenshot is captured, as well as before any bounding rectangle is calculated as part of `options.element`. It receives the Puppeteer 
+		[`Page` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page) as the first argument and the 
+		[`browser` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser) as the second argument.
+		This gives you a lot of power to do custom stuff. The function can be async.
 
 		Note: Make sure to not call `page.close()` or `browser.close()`.
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,8 +208,8 @@ declare namespace captureWebsite {
 		readonly authentication?: Authentication;
 
 		/**
-		The specified function is called right before the screenshot is captured, as well as before any bounding rectangle is calculated as part of `options.element`. It receives the Puppeteer 
-		[`Page` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page) as the first argument and the 
+		The specified function is called right before the screenshot is captured, as well as before any bounding rectangle is calculated as part of `options.element`. It receives the Puppeteer
+		[`Page` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page) as the first argument and the
 		[`browser` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser) as the second argument.
 		This gives you a lot of power to do custom stuff. The function can be async.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,10 +208,7 @@ declare namespace captureWebsite {
 		readonly authentication?: Authentication;
 
 		/**
-		The specified function is called right before the screenshot is captured, as well as before any bounding rectangle is calculated as part of `options.element`. It receives the Puppeteer
-		[`Page` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page) as the first argument and the
-		[`browser` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser) as the second argument.
-		This gives you a lot of power to do custom stuff. The function can be async.
+		The specified function is called right before the screenshot is captured, as well as before any bounding rectangle is calculated as part of `options.element`. It receives the Puppeteer [`Page` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page) as the first argument and the [`browser` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser) as the second argument. This gives you a lot of power to do custom stuff. The function can be async.
 
 		Note: Make sure to not call `page.close()` or `browser.close()`.
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,7 +208,8 @@ declare namespace captureWebsite {
 		readonly authentication?: Authentication;
 
 		/**
-		The specified function is called right before the screenshot is captured. It gives you a lot of power to do custom stuff. The function can be async.
+		The specified function is called right before the screenshot is captured and before the bounding rectangle of `options.element` is calculated.
+		It gives you a lot of power to do custom stuff. The function can be async.
 
 		Note: Make sure to not call `page.close()` or `browser.close()`.
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -118,7 +118,7 @@ declare namespace captureWebsite {
 		readonly waitForElement?: string;
 
 		/**
-		Capture the DOM element matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). It will wait for the element to appear in the page and to be visible. It times out after `options.timeout` seconds
+		Capture the DOM element matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). It will wait for the element to appear in the page and to be visible. It times out after `options.timeout` seconds. Any actions performed as part of `options.beforeScreenshot` occur before this.
 		*/
 		readonly element?: string;
 

--- a/index.js
+++ b/index.js
@@ -294,6 +294,10 @@ const captureWebsite = async (input, options) => {
 		});
 	}
 
+	if (options.beforeScreenshot) {
+		await options.beforeScreenshot(page, browser);
+	}
+
 	if (options.element) {
 		await page.waitForSelector(options.element, {
 			visible: true,
@@ -313,10 +317,6 @@ const captureWebsite = async (input, options) => {
 		} else {
 			await page.$eval(options.scrollToElement, scrollToElement);
 		}
-	}
-
-	if (options.beforeScreenshot) {
-		await options.beforeScreenshot(page, browser);
 	}
 
 	if (screenshotOptions.fullPage) {

--- a/readme.md
+++ b/readme.md
@@ -182,7 +182,7 @@ Wait for a DOM element matching the given [CSS selector](https://developer.mozil
 
 Type: `string`
 
-Capture the DOM element matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). It will wait for the element to appear in the page and to be visible. It times out after `options.timeout` seconds.
+Capture the DOM element matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). It will wait for the element to appear in the page and to be visible. It times out after `options.timeout` seconds. Any actions performed as part of `options.beforeScreenshot` occur before this.
 
 ##### hideElements
 
@@ -389,7 +389,7 @@ Type: `string`
 
 Type: `Function`
 
-The specified function is called right before the screenshot is captured. It receives the Puppeteer [`Page` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page) as the first argument and the [`browser` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser) as the second argument. This gives you a lot of power to do custom stuff. The function can be async.
+The specified function is called right before the screenshot is captured, as well as before any bounding rectangle is calculated as part of `options.element`. It receives the Puppeteer [`Page` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page) as the first argument and the [`browser` instance](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser) as the second argument. This gives you a lot of power to do custom stuff. The function can be async.
 
 Note: Make sure to not call `page.close()` or `browser.close()`.
 


### PR DESCRIPTION
Perform `beforeScreenshot` operation before determining element bounding rectangle. This fixes #69.