### PR TITLE
Remove faulty image loaded check

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,8 +115,6 @@ const parseCookie = (url, cookie) => {
 	return returnValue;
 };
 
-const imagesHaveLoaded = () => [...document.images].map(element => element.complete);
-
 const internalCaptureWebsite = async (input, options) => {
 	options = {
 		launchOptions: {},
@@ -360,9 +358,6 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 			window.scrollTo(0, 0);
 			/* eslint-enable no-undef */
 		});
-
-		// Some extra delay to let images load
-		await page.waitForFunction(imagesHaveLoaded, {timeout: timeoutInMilliseconds});
 	}
 
 	if (options.inset && !screenshotOptions.fullPage) {


### PR DESCRIPTION
I don't think [`HTMLImageElement.complete`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/complete) is doing something there since as MDN article says:

> The read-only HTMLImageElement interface's complete attribute is a Boolean value which indicates whether or not the image has completely loaded.

So in case it returns `false`, it should be combined with something like [`p-wait-for`](https://github.com/sindresorhus/p-wait-for) for re-checking the value until it changes to `true`.