### PR TITLE
workaround fullPage clipping bug by using clip

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,6 +330,7 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		}
 	}
 
+	const {fullPage} = screenshotOptions;
 	if (screenshotOptions.fullPage) {
 		// Get the height of the rendered page
 		const bodyHandle = await page.$('body');
@@ -358,9 +359,30 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 			window.scrollTo(0, 0);
 			/* eslint-enable no-undef */
 		});
+
+		// Include body border using clip
+		screenshotOptions.fullPage = false;
+		/* eslint-disable arrow-body-style */
+		viewportOptions.width = await page.evaluate(_ => {
+			return document.body.scrollWidth;
+		});
+		viewportOptions.height = await page.evaluate(_ => {
+			return document.body.scrollHeight;
+		});
+		const bodyMarginRight = await page.evaluate(_ => {
+			/* eslint-disable no-undef */
+			return window.getComputedStyle(document.body).getPropertyValue('margin-right');
+			/* eslint-enable no-undef */
+		});
+		/* eslint-enable arrow-body-style */
+		const x = 0;
+		const y = 0;
+		const width = viewportOptions.width + Number.parseFloat(bodyMarginRight);
+		const {height} = viewportOptions;
+		screenshotOptions.clip = {x, y, width, height};
 	}
 
-	if (options.inset && !screenshotOptions.fullPage) {
+	if (options.inset && !fullPage) {
 		const inset = {top: 0, right: 0, bottom: 0, left: 0};
 		for (const key of Object.keys(inset)) {
 			if (typeof options.inset === 'number') {

--- a/test.js
+++ b/test.js
@@ -180,8 +180,65 @@ test('`fullPage` option - lazy loading', async t => {
 		fullPage: true,
 	}));
 
-	t.is(size.width, 200);
+	t.is(size.width, 208);
 	t.true(size.height > 150);
+});
+
+test('`fullPage` option - fixed', async t => {
+	const server = await createTestServer();
+
+	server.get('/', async (request, response) => {
+		response.end(`
+			<html>
+			<head>
+			    <style>
+			        .fixed {
+			            position: fixed;
+			            left: 0px;
+			            top: 0px;
+			            width: 100px;
+			            height: 100px;
+			            background: blue;
+			        }
+			        .wide {
+			            width: 2048px;
+			            height: 200px;
+			            background: green;
+			            border: dashed pink 3px;
+			        }
+			        .high {
+			            width: 200px;
+			            height: 2048px;
+			            background: red;
+			        }
+			    </style>
+			</head>
+			<body>
+			    <div class="fixed">
+			        This is fixed.
+			    </div>
+			    <div class="container">
+			        <div class="wide">
+			            This is wide.
+			        </div>
+			        <div class="high">
+			            This is high.
+			        </div>
+			    </div>
+			</body>
+			</html>
+		`);
+	});
+
+	const size = imageSize(await instance(server.url, {
+		width: 200,
+		height: 300,
+		scaleFactor: 1,
+		fullPage: true,
+	}));
+
+	t.is(size.width, 2070);
+	t.is(size.height, 2270);
 });
 
 test('`timeout` option', async t => {


### PR DESCRIPTION
Fixes: #1 

Actually, puppeteer, when using `fullPage: true` does get the whole screen, so no need to scroll around when capturing FIXED items. (So the issueHunt bounty might have to go to someone since it's already fixed.)

However, puppeteer does clip the body's margin-right: ![clipped](https://user-images.githubusercontent.com/1734126/147385405-cda67eac-8e33-4889-ad23-0139dce40767.png)
This PR solves that by getting the body's margin-right and using clip to include it in fullPage.

Of course, if you give me the issueHunt bounty, it will be great :)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1: Full page screenshot](https://issuehunt.io/repos/169625338/issues/1)
---
</details>
<!-- /Issuehunt content-->