### PR TITLE
Add `clip` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ import {
 	EvaluateFn,
 	Protocol,
 	Product,
+	BoundingBox,
 } from 'puppeteer';
 
 export type LaunchOptions = PuppeteerLaunchOptions &
@@ -145,6 +146,31 @@ export interface Options {
 	Capture the DOM element matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). It will wait for the element to appear in the page and to be visible. It times out after `options.timeout` seconds. Any actions performed as part of `options.beforeScreenshot` occur before this.
 	*/
 	readonly element?: string;
+
+	/**
+	Define the screenshot's position and size (clipping region). `x`, `y` indicates the coordinate where the screenshot starts. `width`, `height` indicates the width, height of the screenshot.
+
+	This can be useful when you only need a part of the page.
+
+	You can also consider using `element` option when you have a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
+
+	Note that `clip` and `element` options are mutually exclusive.
+
+	@example
+	```
+	import captureWebsite from 'capture-website';
+
+	await captureWebsite.file('https://sindresorhus.com', 'screenshot.png', {
+		clip: {
+			x: 0,
+			y: 0,
+			width: 400,
+			height: 400
+		}
+	});
+	```
+	*/
+	readonly clip?: BoundingBox;
 
 	/**
 	Hide DOM elements matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).

--- a/index.d.ts
+++ b/index.d.ts
@@ -150,22 +150,13 @@ export interface Options {
 	/**
 	Define the screenshot's position and size (clipping region).
 
-	The position can be specified through `x`, `y` coordinates which starts from left-top.
+	The position can be specified through `x` and `y` coordinates which starts from the top-left.
 
 	This can be useful when you only need a part of the page.
 
 	You can also consider using `element` option when you have a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
 
 	Note that `clip` is mutually exclusive with the `element` and `fullPage` options.
-
-	- **x** - X-coordinate where the screenshot starts.
-	Type: `number`
-	- **y** - Y-coordinate where the screenshot starts.
-	Type: `number`
-	- **width** - The width of the screenshot.
-	Type: `number`
-	- **height** - The height of the screenshot.
-	Type: `number`
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -148,13 +148,24 @@ export interface Options {
 	readonly element?: string;
 
 	/**
-	Define the screenshot's position and size (clipping region). `x`, `y` indicates the coordinate where the screenshot starts. `width`, `height` indicates the width, height of the screenshot.
+	Define the screenshot's position and size (clipping region).
+
+	The position can be specified through `x`, `y` coordinates which starts from left-top.
 
 	This can be useful when you only need a part of the page.
 
 	You can also consider using `element` option when you have a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
 
-	Note that `clip` and `element` options are mutually exclusive.
+	Note that `clip` is mutually exclusive with the `element` and `fullPage` options.
+
+	- **x** - X-coordinate where the screenshot starts.
+	Type: `number`
+	- **y** - Y-coordinate where the screenshot starts.
+	Type: `number`
+	- **width** - The width of the screenshot.
+	Type: `number`
+	- **height** - The height of the screenshot.
+	Type: `number`
 
 	@example
 	```

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const assert = (value, message) => {
 
 const validateOptions = options => {
 	assert(!(options.clip && options.element), 'The `clip` and `element` option are mutually exclusive');
+	assert(!(options.clip && options.fullPage), 'The `clip` and `fullPage` option are mutually exclusive');
 };
 
 const scrollToElement = (element, options) => {

--- a/index.js
+++ b/index.js
@@ -245,9 +245,7 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 	}
 
 	if (options.clip) {
-		viewportOptions.width = options.clip.width;
-		viewportOptions.height = options.clip.height;
-		viewportOptions.deviceScaleFactor = 1;
+		viewportOptions.deviceScaleFactor = options.clip.scaleFactor;
 
 		screenshotOptions.clip = options.clip;
 	}

--- a/index.js
+++ b/index.js
@@ -243,6 +243,14 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		await page.setUserAgent(options.userAgent);
 	}
 
+	if (options.clip) {
+		viewportOptions.width = options.clip.width;
+		viewportOptions.height = options.clip.height;
+		viewportOptions.deviceScaleFactor = 1;
+
+		screenshotOptions.clip = options.clip;
+	}
+
 	await page.setViewport(viewportOptions);
 
 	if (options.emulateDevice) {
@@ -327,10 +335,6 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		});
 		screenshotOptions.clip = await page.$eval(options.element, getBoundingClientRect);
 		screenshotOptions.fullPage = false;
-	}
-
-	if (options.clip) {
-		screenshotOptions.clip = options.clip;
 	}
 
 	if (options.delay) {

--- a/index.js
+++ b/index.js
@@ -245,8 +245,6 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 	}
 
 	if (options.clip) {
-		viewportOptions.deviceScaleFactor = options.clip.scaleFactor;
-
 		screenshotOptions.clip = options.clip;
 	}
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,16 @@ import toughCookie from 'tough-cookie';
 
 const isUrl = string => /^(https?|file):\/\/|^data:/.test(string);
 
+const assert = (value, message) => {
+	if (!value) {
+		throw new Error(message);
+	}
+}
+
+const validateOptions = options => {
+	assert(!(options.clip && options.element), 'The `clip` and `element` option are mutually exclusive');
+};
+
 const scrollToElement = (element, options) => {
 	const isOverflown = element => (
 		element.scrollHeight > element.clientHeight
@@ -121,6 +131,8 @@ const internalCaptureWebsite = async (input, options) => {
 		...options,
 	};
 	const {launchOptions} = options;
+
+	validateOptions(options);
 
 	if (options.debug) {
 		launchOptions.headless = false;
@@ -315,6 +327,10 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		});
 		screenshotOptions.clip = await page.$eval(options.element, getBoundingClientRect);
 		screenshotOptions.fullPage = false;
+	}
+
+	if (options.clip) {
+		screenshotOptions.clip = options.clip;
 	}
 
 	if (options.delay) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const assert = (value, message) => {
 	if (!value) {
 		throw new Error(message);
 	}
-}
+};
 
 const validateOptions = options => {
 	assert(!(options.clip && options.element), 'The `clip` and `element` option are mutually exclusive');

--- a/readme.md
+++ b/readme.md
@@ -469,6 +469,24 @@ Inject a function to be executed prior to navigation.
 
 This can be useful for [altering the JavaScript environment](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pageevaluateonnewdocumentpagefunction-args). For example, you could define a global method on the `window`, overwrite `navigator.languages` to change the language presented by the browser, or mock `Math.random` to return a fixed value.
 
+##### clip
+
+Type: `object`
+
+Define the screenshot's position and size (clipping region).
+This can be useful when you only need a part of the page.
+You can also consider using `element` option when you have a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
+Note that `clip` and `element` options are mutually exclusive.
+
+- **x** - x-coordinate where the screenshot starts
+Type: `number`
+- **y** - y-coordinate where the screenshot starts
+Type: `number`
+- **width** - width of the screenshot
+Type: `number`
+- **height**  - height of the screenshot
+Type: `number`
+
 ### captureWebsite.devices
 
 Type: `string[]`

--- a/readme.md
+++ b/readme.md
@@ -475,6 +475,8 @@ Type: `object`
 
 Define the screenshot's position and size (clipping region).
 
+The position can be specified through `x`, `y` coordinates which starts from left-top.
+
 This can be useful when you only need a part of the page.
 
 You can also consider using `element` option when you have a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).

--- a/readme.md
+++ b/readme.md
@@ -474,20 +474,23 @@ This can be useful for [altering the JavaScript environment](https://github.com/
 Type: `object`
 
 Define the screenshot's position and size (clipping region).
+
 This can be useful when you only need a part of the page.
+
 You can also consider using `element` option when you have a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
-Note that `clip` and `element`, `fullPage` options are mutually exclusive.
 
-- **x** - x-coordinate where the screenshot starts
+Note that `clip` is mutually exclusive with the `element` and `fullPage` options.
+
+- **x** - X-coordinate where the screenshot starts.
 Type: `number`
-- **y** - y-coordinate where the screenshot starts
+- **y** - Y-coordinate where the screenshot starts.
 Type: `number`
-- **width** - Width of the screenshot
+- **width** - The width of the screenshot.
 Type: `number`
-- **height** - Height of the screenshot
+- **height** - The height of the screenshot.
 Type: `number`
 
-Example: Define the screenshot's `width`, and `height` to 400 from 0, 0
+For example, define the screenshot's `width` and `height` to 400 at position (0, 0):
 
 ```js
 import captureWebsite from 'capture-website';

--- a/readme.md
+++ b/readme.md
@@ -476,16 +476,31 @@ Type: `object`
 Define the screenshot's position and size (clipping region).
 This can be useful when you only need a part of the page.
 You can also consider using `element` option when you have a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
-Note that `clip` and `element` options are mutually exclusive.
+Note that `clip` and `element`, `fullPage` options are mutually exclusive.
 
 - **x** - x-coordinate where the screenshot starts
 Type: `number`
 - **y** - y-coordinate where the screenshot starts
 Type: `number`
-- **width** - width of the screenshot
+- **width** - Width of the screenshot
 Type: `number`
-- **height**  - height of the screenshot
+- **height** - Height of the screenshot
 Type: `number`
+
+Example: Define the screenshot's `width`, and `height` to 400 from 0, 0
+
+```js
+import captureWebsite from 'capture-website';
+
+await captureWebsite.file('https://sindresorhus.com', 'screenshot.png', {
+	clip: {
+		x: 0,
+		y: 0,
+		width: 400,
+		height: 400
+	}
+});
+```
 
 ### captureWebsite.devices
 

--- a/readme.md
+++ b/readme.md
@@ -475,7 +475,7 @@ Type: `object`
 
 Define the screenshot's position and size (clipping region).
 
-The position can be specified through `x`, `y` coordinates which starts from left-top.
+The position can be specified through `x` and `y` coordinates which starts from the top-left.
 
 This can be useful when you only need a part of the page.
 

--- a/test.js
+++ b/test.js
@@ -888,8 +888,6 @@ test('`preloadFunction` option', async t => {
 
 test('`clip` option', async t => {
 	const size = imageSize(await instance(server.url, {
-		width: 100,
-		height: 200,
 		scaleFactor: 1,
 		clip: {
 			x: 10,
@@ -905,8 +903,6 @@ test('`clip` option', async t => {
 test('option validation - The `clip` and `element` option are mutually exclusive', async t => {
 	const expectedErrorMessage = 'The `clip` and `element` option are mutually exclusive';
 	const options = {
-		width: 100,
-		height: 100,
 		element: 'html',
 		clip: {
 			x: 1,

--- a/test.js
+++ b/test.js
@@ -914,3 +914,19 @@ test('option validation - The `clip` and `element` option are mutually exclusive
 
 	t.is(error.message, expectedErrorMessage);
 });
+
+test('option validation - The `clip` and `fullPage` option are mutually exclusive', async t => {
+	const expectedErrorMessage = 'The `clip` and `fullPage` option are mutually exclusive';
+	const options = {
+		fullPage: true,
+		clip: {
+			x: 1,
+			y: 10,
+			width: 10,
+			height: 100,
+		},
+	};
+	const error = await t.throwsAsync(captureWebsite.base64(server.url, options));
+
+	t.is(error.message, expectedErrorMessage);
+});

--- a/test.js
+++ b/test.js
@@ -888,6 +888,7 @@ test('`preloadFunction` option', async t => {
 
 test('`clip` option', async t => {
 	const size = imageSize(await instance(server.url, {
+		scaleFactor: 1,
 		clip: {
 			x: 10,
 			y: 30,

--- a/test.js
+++ b/test.js
@@ -885,3 +885,37 @@ test('`preloadFunction` option', async t => {
 
 	await server.close();
 });
+
+test('`clip` option', async t => {
+	const size = imageSize(await instance(server.url, {
+		width: 100,
+		height: 200,
+		scaleFactor: 1,
+		clip: {
+			x: 10,
+			y: 30,
+			width: 500,
+			height: 300
+		}
+	}));
+	t.is(size.width, 500);
+	t.is(size.height, 300);
+});
+
+test('option validation - The `clip` and `element` option are mutually exclusive', async t => {
+	const expectedErrorMessage = 'The `clip` and `element` option are mutually exclusive';
+	const options = {
+		width: 100,
+		height: 100,
+		element: 'html',
+		clip: {
+			x: 1,
+			y: 10,
+			width: 10,
+			height: 100
+		}
+	};
+	const error = await t.throwsAsync(captureWebsite.base64(server.url, options));
+
+	t.is(error.message, expectedErrorMessage);
+});

--- a/test.js
+++ b/test.js
@@ -892,8 +892,8 @@ test('`clip` option', async t => {
 			x: 10,
 			y: 30,
 			width: 500,
-			height: 300
-		}
+			height: 300,
+		},
 	}));
 	t.is(size.width, 500);
 	t.is(size.height, 300);
@@ -907,8 +907,8 @@ test('option validation - The `clip` and `element` option are mutually exclusive
 			x: 1,
 			y: 10,
 			width: 10,
-			height: 100
-		}
+			height: 100,
+		},
 	};
 	const error = await t.throwsAsync(captureWebsite.base64(server.url, options));
 

--- a/test.js
+++ b/test.js
@@ -888,7 +888,6 @@ test('`preloadFunction` option', async t => {
 
 test('`clip` option', async t => {
 	const size = imageSize(await instance(server.url, {
-		scaleFactor: 1,
 		clip: {
 			x: 10,
 			y: 30,


### PR DESCRIPTION
Fixes #20.

I tried to reflect on the feedbacks, elaborate on the `clip` option.

Please let me know if we should have more detailed descriptions on the document.

# Notes

- In my thought, using `fullPage` option with `clip` does not make sense. Should I add `fullPage` to [the assert statement ](https://github.com/sindresorhus/capture-website/pull/97/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R17) like below way? (and related test)

```ts
const validateOptions = options => {
	assert(!(options.clip && options.element), 'The `clip` and `element` options are mutually exclusive');
        assert(!(options.clip && options.fullPage), 'The `fullPage` and `element` options are mutually exclusive');
};
```

- When width, height are specified on duplicate like below code, clip's width and height are set in `viewportOptions` later. In this case, I think it would be better to let users know that there are some ignored options by some warning. (Or adding assert statements to `validateOptions` would be better.)

```js
import captureWebsite from 'capture-website';
	await captureWebsite.file('https://sindresorhus.com', 'screenshot.png', {
                width: 500,
                height: 400,
		clip: {
			x: 0,
			y: 0,
			width: 400,
			height: 400
		}
	});
```

- I fixed `scaleFactor` to 1 when `clip` option is given because otherwise, the screenshot result would be different from what is specified in the `clip`.