### PR TITLE
Support ad blocking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -220,11 +220,11 @@ export interface Options {
 	readonly disableAnimations?: boolean;
 
 	/**
-	Disable [Ad Blocker](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md).
+	Enable [Ad Blocker](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md).
 
 	@default false
 	*/
-	readonly disableAdBlocker?: boolean;
+	readonly blockAds?: boolean;
 
 	/**
 	Whether JavaScript on the website should be executed.

--- a/index.d.ts
+++ b/index.d.ts
@@ -220,6 +220,13 @@ export interface Options {
 	readonly disableAnimations?: boolean;
 
 	/**
+	Disable [Ad Blocker](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md).
+
+	@default false
+	*/
+	readonly disableAdBlocker?: boolean;
+
+	/**
 	Whether JavaScript on the website should be executed.
 
 	This does not affect the `scripts` and `modules` options.

--- a/index.d.ts
+++ b/index.d.ts
@@ -220,9 +220,9 @@ export interface Options {
 	readonly disableAnimations?: boolean;
 
 	/**
-	Enable [Ad Blocker](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md).
+	[Ad blocking.](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md)
 
-	@default false
+	@default true
 	*/
 	readonly blockAds?: boolean;
 

--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ const internalCaptureWebsite = async (input, options) => {
 		browser = options._browser || await puppeteer.launch(launchOptions);
 		page = await browser.newPage();
 
-		if (!options.disableAdBlocker) {
+		if (options.blockAds) {
 			const blocker = await PuppeteerBlocker.fromPrebuiltFull(fetch, {
 				path: 'engine.bin',
 				read: fs.readFile,
@@ -184,7 +184,7 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		darkMode: false,
 		_keepAlive: false,
 		isJavaScriptEnabled: true,
-		disableAdBlocker: false,
+		blockAds: true,
 		inset: 0,
 		...options,
 	};

--- a/index.js
+++ b/index.js
@@ -148,13 +148,15 @@ const internalCaptureWebsite = async (input, options) => {
 		browser = options._browser || await puppeteer.launch(launchOptions);
 		page = await browser.newPage();
 
-		const blocker = await PuppeteerBlocker.fromPrebuiltFull(fetch, {
-			path: 'engine.bin',
-			read: fs.readFile,
-			write: fs.writeFile,
-		});
+		if (!options.disableAdBlocker) {
+			const blocker = await PuppeteerBlocker.fromPrebuiltFull(fetch, {
+				path: 'engine.bin',
+				read: fs.readFile,
+				write: fs.writeFile,
+			});
 
-		await blocker.enableBlockingInPage(page);
+			await blocker.enableBlockingInPage(page);
+		}
 
 		return await internalCaptureWebsiteCore(input, options, page, browser);
 	} finally {
@@ -182,6 +184,7 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		darkMode: false,
 		_keepAlive: false,
 		isJavaScriptEnabled: true,
+		disableAdBlocker: false,
 		inset: 0,
 		...options,
 	};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ import {promises as fs} from 'node:fs';
 import fileUrl from 'file-url';
 import puppeteer from 'puppeteer';
 import toughCookie from 'tough-cookie';
+import {PuppeteerBlocker} from '@cliqz/adblocker-puppeteer';
+import fetch from 'node-fetch';
 
 const isUrl = string => /^(https?|file):\/\/|^data:/.test(string);
 
@@ -145,6 +147,15 @@ const internalCaptureWebsite = async (input, options) => {
 	try {
 		browser = options._browser || await puppeteer.launch(launchOptions);
 		page = await browser.newPage();
+
+		const blocker = await PuppeteerBlocker.fromPrebuiltFull(fetch, {
+			path: 'engine.bin',
+			read: fs.readFile,
+			write: fs.writeFile,
+		});
+
+		await blocker.enableBlockingInPage(page);
+
 		return await internalCaptureWebsiteCore(input, options, page, browser);
 	} finally {
 		if (page) {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
 		"jpg"
 	],
 	"dependencies": {
+		"@cliqz/adblocker-puppeteer": "^1.23.2",
 		"file-url": "^4.0.0",
 		"puppeteer": "^13.1.1",
+		"node-fetch": "^3.1.0",
 		"tough-cookie": "^4.0.0"
 	},
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -243,12 +243,12 @@ Default: `false`
 
 Disable CSS [animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) and [transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition).
 
-##### disableAdBlocker
+##### blockAds
 
 Type: `boolean`\
-Default: `false`
+Default: `true`
 
-Disable [Ad Blocker](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md).
+Enable [Ad Blocker](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md).
 
 ##### isJavaScriptEnabled
 

--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,7 @@ Disable CSS [animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animat
 Type: `boolean`\
 Default: `true`
 
-Enable [Ad Blocker](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md).
+[Ad blocking.](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md)
 
 ##### isJavaScriptEnabled
 

--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,13 @@ Default: `false`
 
 Disable CSS [animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) and [transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition).
 
+##### disableAdBlocker
+
+Type: `boolean`\
+Default: `false`
+
+Disable [Ad Blocker](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-puppeteer/README.md).
+
 ##### isJavaScriptEnabled
 
 Type: `boolean`\


### PR DESCRIPTION
Fixes #7.

 I think we could use `@cliqz/adblocker-puppeteer` package to support ad blocking.

# Notes

- This draft PR does not include the option representing whether to use the ad-blocker, related option, type, tests and documentations yet. 

- If I'm on the right way, I'd appreciate it if you could let me know. Then I will try to do the next works.