### PR TITLE
fix element null check

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const scrollToElement = (element, options) => {
 	);
 
 	const findScrollParent = element => {
-		if (element === undefined) {
+		if (element === null) {
 			return;
 		}
 


### PR DESCRIPTION
element.parentElement will return null when no parent, not undefined.

it will throw error when user set scrollToElement and the webpage doesn't have any overflow containers.