### PR TITLE
fix: The height of the BoundingBox should be taken

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,7 +383,7 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		// Scroll one viewport at a time, pausing to let content load
 		const viewportHeight = viewportOptions.height;
 		let viewportIncrement = 0;
-		while (viewportIncrement + viewportHeight < bodyBoundingHeight) {
+		while (viewportIncrement + viewportHeight < bodyBoundingHeight.height) {
 			const navigationPromise = page.waitForNavigation({waitUntil: 'networkidle0'});
 			/* eslint-disable no-await-in-loop */
 			await page.evaluate(_viewportHeight => {

--- a/index.js
+++ b/index.js
@@ -384,7 +384,7 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		const viewportHeight = viewportOptions.height;
 		let viewportIncrement = 0;
 		while (viewportIncrement + viewportHeight < bodyBoundingHeight.height) {
-			const navigationPromise = page.waitForNavigation({waitUntil: 'networkidle0'});
+			const navigationPromise = page.waitForNetworkIdle();
 			/* eslint-disable no-await-in-loop */
 			await page.evaluate(_viewportHeight => {
 				/* eslint-disable no-undef */

--- a/index.js
+++ b/index.js
@@ -377,13 +377,13 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 	if (screenshotOptions.fullPage) {
 		// Get the height of the rendered page
 		const bodyHandle = await page.$('body');
-		const bodyBoundingHeight = await bodyHandle.boundingBox();
+		const bodyBoundingBox = await bodyHandle.boundingBox();
 		await bodyHandle.dispose();
 
 		// Scroll one viewport at a time, pausing to let content load
 		const viewportHeight = viewportOptions.height;
 		let viewportIncrement = 0;
-		while (viewportIncrement + viewportHeight < bodyBoundingHeight.height) {
+		while (viewportIncrement + viewportHeight < bodyBoundingBox.height) {
 			const navigationPromise = page.waitForNetworkIdle();
 			/* eslint-disable no-await-in-loop */
 			await page.evaluate(_viewportHeight => {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 	"dependencies": {
 		"@cliqz/adblocker-puppeteer": "^1.26.11",
 		"file-url": "^4.0.0",
-		"puppeteer": "^21.5.0",
+		"puppeteer": "^21.9.0",
 		"tough-cookie": "^4.1.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
It's a great tool, I found one small problem, `BoundingBox` is an object, not a specific height. and waitForNavigation just waits for the page to navigate to a new URL or to reload, no routing when scrolling down, it will cause a timeout error

Maybe you have a better solution, looking forward to your reply!

refer:
[waitForNavigation](https://pptr.dev/api/puppeteer.page.waitfornavigation)
[BoundingBox](https://pptr.dev/api/puppeteer.boundingbox)

