### PR TITLE
feat: change to new headless mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -379,7 +379,7 @@ export type Options = {
 
 	Note: Some of the launch options are overridden by the `debug` option.
 
-	@default {}
+	@default { headless: 'new' }
 	*/
 	readonly launchOptions?: PuppeteerLaunchOptions;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -379,7 +379,7 @@ export type Options = {
 
 	Note: Some of the launch options are overridden by the `debug` option.
 
-	@default { headless: 'new' }
+	@default {headless: 'new'}
 	*/
 	readonly launchOptions?: PuppeteerLaunchOptions;
 

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ const parseCookie = (url, cookie) => {
 
 const internalCaptureWebsite = async (input, options) => {
 	options = {
-		launchOptions: {},
+		launchOptions: {headless: 'new'},
 		...options,
 	};
 	const {launchOptions} = options;

--- a/readme.md
+++ b/readme.md
@@ -454,7 +454,7 @@ await captureWebsite.file('index.html', 'screenshot.png', {
 ##### launchOptions
 
 Type: `object`\
-Default: `{}`
+Default: `{ headless: 'new' }`
 
 Options passed to [`puppeteer.launch()`](https://pptr.dev/api/puppeteer.puppeteernodelaunchoptions).
 

--- a/readme.md
+++ b/readme.md
@@ -454,7 +454,7 @@ await captureWebsite.file('index.html', 'screenshot.png', {
 ##### launchOptions
 
 Type: `object`\
-Default: `{ headless: 'new' }`
+Default: `{headless: 'new'}`
 
 Options passed to [`puppeteer.launch()`](https://pptr.dev/api/puppeteer.puppeteernodelaunchoptions).
 


### PR DESCRIPTION
[as puppeteer doc](https://pptr.dev/#default-runtime-settings)

change to `new` headless mode, and eliminate console warnings