### PR TITLE
feat: Quality of the image, between 0-100. Not applicable to png images.

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,6 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		screenshotOptions.type = options.type;
 	}
 
-	// Quality of the image, between 0-100. Not applicable to png images.
 	if (typeof options.quality === 'number' && options.type && options.type !== 'png') {
 		screenshotOptions.quality = options.quality * 100;
 	}

--- a/index.js
+++ b/index.js
@@ -216,7 +216,8 @@ const internalCaptureWebsiteCore = async (input, options, page, browser) => {
 		screenshotOptions.type = options.type;
 	}
 
-	if (options.quality) {
+	// Quality of the image, between 0-100. Not applicable to png images.
+	if (typeof options.quality === 'number' && options.type && options.type !== 'png') {
 		screenshotOptions.quality = options.quality * 100;
 	}
 


### PR DESCRIPTION
[puppeteer doc](https://pptr.dev/api/puppeteer.screenshotoptions/#properties)

> Quality of the image, between 0-100. Not applicable to png images. 

Passing in the quality parameter for the png type will cause an exception. So do a checksum to avoid users passing parameters by mistake