### PR TITLE
fix(readme): Devices link to the puppeteer repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ The default is what you would get if you captured a normal screenshot on a compu
 ##### emulateDevice
 
 Type: `string`\
-Values: [Devices](https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts) *(Use the `name` property)*
+Values: [Devices](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/common/Device.ts) *(Use the `name` property)*
 
 Make it look like the screenshot was taken on the specified device.
 


### PR DESCRIPTION
Hello,

Old link is leading to 404 and this PR fixes the link to the `Devices.ts` file in currently structured puppeteer monorepo. 